### PR TITLE
Upgrade syn to v2.0

### DIFF
--- a/dyn-clonable-impl/Cargo.toml
+++ b/dyn-clonable-impl/Cargo.toml
@@ -14,7 +14,7 @@ quote = "1.0"
 
 [dependencies.syn]
 features = ["full"]
-version = "1.0"
+version = "2.0"
 
 [dev-dependencies]
 dyn-clone = "1.0"


### PR DESCRIPTION
This will allow consuming libraries that don't otherwise use syn v1 to drop that dependency.